### PR TITLE
Enhancement suggestion: change foreground/background colors of tabs to improve readability

### DIFF
--- a/flavors/rose-pine-dawn.yazi/flavor.toml
+++ b/flavors/rose-pine-dawn.yazi/flavor.toml
@@ -44,8 +44,8 @@ syntect_theme = ""
 # : Tabs {{{
 
 [tabs]
-active   = { fg = "#575279", bg = "#286983", bold = true }
-inactive = { fg = "#286983", bg = "#575279" }
+active   = { fg = "#faf4ed", bg = "#56949f", bold = true }
+inactive = { fg = "#56949f", bg = "#faf4ed" }
 
 # Separator
 sep_inner = { open = "", close = "" }


### PR DESCRIPTION
First of all, thank you for creating this great theme!
I noticed a slight difficulty in reading tab titles when using rose-pine-dawn variant of yazi, so this PR is intended to improve the readability in that.

Before change:
<img width="448" height="139" alt="before" src="https://github.com/user-attachments/assets/11b076b4-e8ac-4e16-b824-9131f1c7d40d" />

After change:
<img width="448" height="139" alt="after" src="https://github.com/user-attachments/assets/6a715a6b-e808-4809-b2d3-32f2dba83259" />
